### PR TITLE
Do 441 growth ci cd for bigdipper from building stage to k8s

### DIFF
--- a/.github/workflows/build-bd-juno.yaml
+++ b/.github/workflows/build-bd-juno.yaml
@@ -1,0 +1,64 @@
+# This is a basic workflow to help you get started with Actions
+name: Build Big Dipper Juno
+
+# Controls when the workflow will run
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  main:
+    environment: Configure CI/CD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-region: us-east-1
+          role-to-assume: arn:aws:iam::529724559987:role/gh-action-cicd
+          role-session-name: bd-core-build
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build, tag, and push docker image to Amazon ECR
+        env:
+          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker buildx build -t $REGISTRY/bd-core:$IMAGE_TAG \
+            -t $REGISTRY/bd-core:latest \
+            -f Dockerfile . \
+            --platform linux/amd64 \
+            --cache-from="type=local,src=/tmp/.buildx-cache" \
+            --cache-to="type=local,dest=/tmp/.buildx-cache-new" --load . \
+            --push
+
+        # Necessary if you don't want your cache to grow forever, until
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache || true
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache || true

--- a/.github/workflows/build-bd-juno.yaml
+++ b/.github/workflows/build-bd-juno.yaml
@@ -3,6 +3,9 @@ name: Build Big Dipper Juno
 
 # Controls when the workflow will run
 on:
+  push:
+    branches:
+      - lava
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
Github action to build docker image for bd-juno. Need to add AWS credentials as a secret.